### PR TITLE
Added non-rigorous 'wrap around' test

### DIFF
--- a/hw2/jtest-clist.cpp
+++ b/hw2/jtest-clist.cpp
@@ -121,6 +121,21 @@ TEST(ListJTest, FillEmptyFill) {
 	delete list;
 }
 
+TEST(ListJTest, WrapAround) {
+	std::vector<int> contents;
+	CircularListInt *list = new CircularListInt();
+
+	for (int i = 0; i < 10; i++) {
+        	contents.push_back(i);
+        	list->push_back(i);
+	}
+
+	EXPECT_EQ(list->get(5), list->get(15));
+	EXPECT_EQ(list->get(0), list->get(10));
+
+	delete list;
+}
+
 TEST(ListJTestStress, TenThousandListCreate) {
 	std::vector<int> contents;
 	for (int i = -5000; i <= 5000; i++) {


### PR DESCRIPTION
Added a simple, non-rigorous test for wrap around. It can still be circumvented by the user using `index %= count` in their code.

However, a better test to actually make sure the list is circular would be making the Item struct public in the header file, adding a `Item* CircularListInt::getItem(size_t index) const` (that the user would make/write) in the header, and then adding a test along the lines of

```
std::vector<int> contents;
CircularListInt *list = new CircularListInt();

    for (int i = 0; i < 10; i++) {
        contents.push_back(i);
        list->push_back(i);
    }

Item* LastIndex = list.getItem(9)
Item* Head = list.getItem(0)


EXPECT_EQ(LastIndex->next, Head);
EXPECT_EQ(Head->prev, LastIndex);
```
Just a suggestion