### PR TITLE
Edits to cmake

### DIFF
--- a/hw3/hw3-check/CMakeLists.txt
+++ b/hw3/hw3-check/CMakeLists.txt
@@ -56,12 +56,13 @@ if(NOT DEFINED HW3_DIR)
 endif()
 
 # build loose user code as a CMake library
+# Note: add any additional .cpp files you made here
 # ----------------------------------------------------------
 
 set(HW3_SOURCES
 	${HW3_DIR}/stackint.cpp
 	${HW3_DIR}/circular_list_int.cpp
-	${HW3_DIR}/parser)
+	${HW3_DIR}/parser.cpp)
 
 # first check that we have the right sources
 foreach(HW3_SOURCE ${HW3_SOURCES})
@@ -78,9 +79,12 @@ target_include_directories(hw3_user_code PUBLIC ${HW3_DIR})
 target_compile_definitions(hw3_user_code PRIVATE main=disabled_main)
 
 # build user executable
+# Note: add any addition .cpp or .h you made similar to how parser.cpp was added
 # ----------------------------------------------------------
 
-add_executable(${HW3_DIR}/parser)
+add_executable(parser
+		${HW3_DIR}/parser.cpp
+		)
 
 # build testing utils lib
 # ----------------------------------------------------------


### PR DESCRIPTION
Minor edits to allow it to compile. Users will still have to make local edits if they don't follow the standard/base parser.cpp and parser.h implementation of the last problem.