### PR TITLE
Add parser test utility

### DIFF
--- a/hw3/hw3-check/testing_utils/parser_utils.cpp
+++ b/hw3/hw3-check/testing_utils/parser_utils.cpp
@@ -1,0 +1,37 @@
+#include <fstream>
+#include <sstream>
+
+#include <kwsys/SystemTools.hxx>
+
+#include "parser_utils.h"
+
+testing::AssertionResult runParserProgram(std::string equation, std::string testName)
+{
+	// set up file structure
+	std::string executablePath = DDG_EXECUTABLE;
+	std::string testFolder =  TEST_BINARY_DIR "/parser_tests/testFiles/" + testName;
+	kwsys::SystemTools::MakeDirectory(testFolder);
+	std::string configFilePath = testFolder + "/input.txt";
+
+	// create input file
+	{
+		std::ofstream inputFile(inputFilePath);
+
+		if(!inputFile)
+		{
+			return testing::AssertionFailure() << "Couldn't create input file " << inputFilePath;
+		}
+
+		inputFile << equation;
+	}
+
+	// run the program
+	UserCodeRunner parserRunner(testFolder, executablePath, {inputFilePath}, true);
+	testing::AssertionResult result = parserRunner.execute();
+
+	if(!result)
+	{
+		return result;
+	}
+
+};

--- a/hw3/hw3-check/testing_utils/parser_utils.cpp
+++ b/hw3/hw3-check/testing_utils/parser_utils.cpp
@@ -8,7 +8,7 @@
 testing::AssertionResult runParserProgram(std::string equation, std::string testName)
 {
 	// set up file structure
-	std::string executablePath = DDG_EXECUTABLE;
+	std::string executablePath = PARSER_EXECUTABLE;
 	std::string testFolder =  TEST_BINARY_DIR "/parser_tests/testFiles/" + testName;
 	kwsys::SystemTools::MakeDirectory(testFolder);
 	std::string configFilePath = testFolder + "/input.txt";

--- a/hw3/hw3-check/testing_utils/parser_utils.h
+++ b/hw3/hw3-check/testing_utils/parser_utils.h
@@ -2,8 +2,8 @@
 // Utilities for the Parser tests
 //
 
-#ifndef CS104_HW2_TEST_SUITE_PARSER_UTILS_H
-#define CS104_HW2_TEST_SUITE_PARSER_UTILS_H
+#ifndef CS104_HW3_TEST_SUITE_PARSER_UTILS_H
+#define CS104_HW3_TEST_SUITE_PARSER_UTILS_H
 
 #include "user_code_runner.h"
 
@@ -14,5 +14,4 @@
 // runs the user's parser executable with the given string "equation" as the input file.
 testing::AssertionResult runParserProgram(std::string equation, std::string testName);
 
-#endif //CS104_HW2_TEST_SUITE_DUCK_DUCK_GOOSE_UTILS_H
-
+#endif

--- a/hw3/hw3-check/testing_utils/parser_utils.h
+++ b/hw3/hw3-check/testing_utils/parser_utils.h
@@ -1,0 +1,18 @@
+//
+// Utilities for the Parser tests
+//
+
+#ifndef CS104_HW2_TEST_SUITE_PARSER_UTILS_H
+#define CS104_HW2_TEST_SUITE_PARSER_UTILS_H
+
+#include "user_code_runner.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+// runs the user's parser executable with the given string "equation" as the input file.
+testing::AssertionResult runParserProgram(std::string equation, std::string testName);
+
+#endif //CS104_HW2_TEST_SUITE_DUCK_DUCK_GOOSE_UTILS_H
+


### PR DESCRIPTION
Used some of the duck_duck_goose code from hw2 to make a test utility for parser. I haven't tested it, but I'm pretty sure it should work. Right now, it takes a string to act as the input.txt