### PR TITLE
Minor edit to class inheritance

### DIFF
--- a/hw6/hw6-check/heap_tests/heap_tests.cpp
+++ b/hw6/hw6-check/heap_tests/heap_tests.cpp
@@ -13,7 +13,6 @@
 using namespace std;
 
 /*** Test Fixtures ***/
-
 class MinHeapNum : public ::testing::Test {
 protected:
   MinHeap<int>* mh;
@@ -31,7 +30,7 @@ class MinHeapNumParam : public MinHeapNum, public ::testing::WithParamInterface<
 protected:
 };
 
-class MinHeapSort : public ::testing::Test, public ::testing::WithParamInterface<int> {
+class MinHeapSort : public ::testing::TestWithParam<int> {
 protected:
   MinHeap<int>* mh;
   size_t array_size;


### PR DESCRIPTION
Changed a line to fit with the [documentation](https://github.com/google/googletest/blob/master/googletest/docs/advanced.md) (don't read it; it's long af). Aside from that, I think the heap tests are looking pretty optimized in terms of cool features/tricks. 

Side note: If you're planning to add a few non-paramaterized stress tests for pops/inserts (that say uses an absurdly giant heap with fixed d), consider using `SetUpTestCase` and `TearDownTestCase` to avoid having to declare a new heap each time. Not sure if it'll change much though :thinking:, but maybe worth looking at later. 