### PR TITLE
Move tests from TearDown into separate function

### DIFF
--- a/hw6/hw6-check/color_tests/color_tests.cpp
+++ b/hw6/hw6-check/color_tests/color_tests.cpp
@@ -29,7 +29,7 @@ protected:
     this->expected = expected;
   }
 
-  virtual void TearDown() {
+  virtual void runTest() {
     EXPECT_TRUE(runColor(output, testName, letter_count, row_count, col_count, map));
 
     stringstream ss;
@@ -49,6 +49,7 @@ TEST_F(ColorTest, Provided) {
               "BBBBBACDEEEDD\n"
               "BBBBBBDDDDDDD\n";
   SetUp("Provided", s, 5, 6, 13, {1, 2, 2, 1, 3});
+  runTest();
 }
 
 TEST_F(ColorTest, Provided2) {
@@ -57,6 +58,7 @@ TEST_F(ColorTest, Provided2) {
               "FAABBCCF\n"
               "FFFFFFFF\n";
   SetUp("Provided2", s, 6, 4, 8, {1, 2, 3, 1, 3, 4});
+  runTest();
 }
 
 TEST_F(ColorTest, Provided3) {
@@ -71,6 +73,7 @@ TEST_F(ColorTest, Provided3) {
               "FFFFFFFFFFFFFFF\n"
               "FFFFFFFFFFFFFFF\n";
   SetUp("Provided3", s, 6, 10, 15, {1, 2, 3, 1, 3, 4});
+  runTest();
 }
 
 TEST_F(ColorTest, AllAs) {
@@ -82,6 +85,7 @@ TEST_F(ColorTest, AllAs) {
               "AAAAAAAAAAAAA \n";
 
   SetUp("AllAs", s, 1, 6, 13, {1});
+  runTest();
 }
 
 TEST_F(ColorTest, NarrowPath) {
@@ -92,4 +96,5 @@ TEST_F(ColorTest, NarrowPath) {
               "ABCDEFGHIJ\n";
 
   SetUp("NarrowPath", s, 10, 5, 10, {1,2,1,2,1,2,1,2,1,2});
+  runTest();
 }

--- a/hw6/hw6-check/heap_tests/heap_tests.cpp
+++ b/hw6/hw6-check/heap_tests/heap_tests.cpp
@@ -39,7 +39,7 @@ protected:
 	this->array_size = array_size;
   }
 
-  void TearDown() {
+  void sortTest() {
 	mh = new MinHeap<int>(GetParam());
 	vector<int> vec = makeRandomNumberVector(array_size, 0, 2147483646, 12345, true);
 	vector<int> vec2 = makeRandomNumberVector(array_size, 0, 2147483646, 12345, false);
@@ -221,14 +221,17 @@ INSTANTIATE_TEST_CASE_P(MinHeapSortVaryingD, MinHeapSort, ::testing::Range(2, 10
 /* Perform heap sort with 100 elements and k-ary heaps in steps of 1 */
 TEST_P (MinHeapSort, HeapSort100) {
   SetUp(100);
+  sortTest();
 }
 
 /* Perform heap sort with 10000 elements and k-ary heaps in steps of 3 */
 TEST_P (MinHeapSort, HeapSort543) {
   SetUp(543);
+  sortTest();
 }
 
 /* Perform heap sort with 1000 elements and k-ary heaps in steps of 3 */
 TEST_P (MinHeapSort, HeapSort1000) {
   SetUp(1000);
+  sortTest();
 }

--- a/hw6/hw6-check/search_tests/search_tests.cpp
+++ b/hw6/hw6-check/search_tests/search_tests.cpp
@@ -29,7 +29,7 @@ protected:
     this->expected = expected;
   }
 
-  virtual void TearDown() {
+  virtual void runTest() {
     EXPECT_TRUE(runSearch(output, testName, letter_count, row_count, col_count, map));
 
     try {
@@ -51,6 +51,7 @@ TEST_F(SearchTest, Provided) {
               "BBBBBBAAAAAAA \n";
 
   SetUp("Provided", s, 3, 6, 13, 21);
+  runTest();
 }
 
 TEST_F(SearchTest, Provided2) {
@@ -60,6 +61,7 @@ TEST_F(SearchTest, Provided2) {
               "FFFFFFFF \n";
 
   SetUp("Provided2", s, 6, 4, 8, 20);
+  runTest();
 }
 
 TEST_F(SearchTest, Provided3) {
@@ -75,6 +77,7 @@ TEST_F(SearchTest, Provided3) {
                 "FFFFFFFFFFFFFFF\n";
 
   SetUp("Provided3", s, 6, 10, 15, 84);
+  runTest();
 }
 
 TEST_F(SearchTest, AllAs) {
@@ -86,6 +89,7 @@ TEST_F(SearchTest, AllAs) {
               "AAAAAAAAAAAAA \n";
 
   SetUp("AllAs", s, 1, 6, 13, 78);
+  runTest();
 }
 
 TEST_F(SearchTest, NarrowPath) {
@@ -96,6 +100,7 @@ TEST_F(SearchTest, NarrowPath) {
               "ABACABABAB\n";
 
   SetUp("NarrowPath", s, 3, 5, 10, 11);
+  runTest();
 }
 
 TEST_F(SearchTest, UniqueLetters) {
@@ -103,6 +108,7 @@ TEST_F(SearchTest, UniqueLetters) {
               "KLMNOPQRST \n";
 
   SetUp("UniqueLetters", s, 20, 2, 10, 1);
+  runTest();
 }
 
 TEST_F(SearchTest, TwoByTwo) {
@@ -110,6 +116,7 @@ TEST_F(SearchTest, TwoByTwo) {
               "AB \n";
 
   SetUp("TwoByTwo", s, 3, 2, 2, 2);
+  runTest();
 }
 
 TEST_F(SearchTest, BorderingAcross) {
@@ -120,6 +127,7 @@ TEST_F(SearchTest, BorderingAcross) {
               "BBBBBABACC\n";
 
   SetUp("BorderingAcross", s, 3, 5, 10, 13);
+  runTest();
 }
 
 TEST_F(SearchTest, Heart) {
@@ -145,5 +153,6 @@ TEST_F(SearchTest, Heart) {
                 "BBBBBBBBBBBBBAAAAABBBBBBBBBBBBBBBBBB\n"
                 "BBBBBBBBBBBBBBAAABBBBBBBBBBBBBBBBBBB\n"
                 "BBBBBBBBBBBBBBBABBBBBBBBBBBBBBBBBBBB\n";
-    SetUp("Heart", s, 3, 22, 36, 224);
+  SetUp("Heart", s, 3, 22, 36, 224);
+  runTest();
 }


### PR DESCRIPTION
No new tests, but this format should be closer to industry practice and more modular (since putting stuff in TearDown was a bit improper). I think it'd be best to just use TearDown for undoing anything in SetUp from now on.